### PR TITLE
Default saturation_from_dict to default_priors

### DIFF
--- a/pymc_marketing/mmm/components/adstock.py
+++ b/pymc_marketing/mmm/components/adstock.py
@@ -405,7 +405,8 @@ def adstock_from_dict(data: dict) -> AdstockTransformation:
     lookup_name = data.pop("lookup_name")
     cls = ADSTOCK_TRANSFORMATIONS[lookup_name]
 
-    data["priors"] = {k: Prior.from_json(v) for k, v in data["priors"].items()}
+    if "priors" in data:
+        data["priors"] = {k: Prior.from_json(v) for k, v in data["priors"].items()}
     return cls(**data)
 
 

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -465,9 +465,10 @@ def saturation_from_dict(data: dict) -> SaturationTransformation:
     data = data.copy()
     cls = SATURATION_TRANSFORMATIONS[data.pop("lookup_name")]
 
-    data["priors"] = {
-        key: Prior.from_json(value) for key, value in data["priors"].items()
-    }
+    if "priors" in data:
+        data["priors"] = {
+            key: Prior.from_json(value) for key, value in data["priors"].items()
+        }
     return cls(**data)
 
 

--- a/tests/mmm/components/test_adstock.py
+++ b/tests/mmm/components/test_adstock.py
@@ -178,6 +178,24 @@ def test_adstock_from_dict() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "adstock",
+    adstocks(),
+)
+def test_adstock_from_dict_without_priors(adstock) -> None:
+    data = {
+        "lookup_name": adstock.lookup_name,
+        "l_max": 10,
+        "prefix": "test",
+        "mode": "Before",
+    }
+
+    adstock = adstock_from_dict(data)
+    assert adstock.default_priors == {
+        k: Prior.from_json(v) for k, v in adstock.to_dict()["priors"].items()
+    }
+
+
 def test_register_adstock_transformation() -> None:
     class NewTransformation(AdstockTransformation):
         lookup_name: str = "new_transformation"

--- a/tests/mmm/components/test_saturation.py
+++ b/tests/mmm/components/test_saturation.py
@@ -258,3 +258,15 @@ def test_saturation_from_dict() -> None:
             "lam": Prior("HalfNormal", sigma=1),
         }
     )
+
+
+@pytest.mark.parametrize("saturation", saturation_functions())
+def test_saturation_from_dict_without_priors(saturation) -> None:
+    data = {
+        "lookup_name": saturation.lookup_name,
+    }
+
+    saturation = saturation_from_dict(data)
+    assert saturation.default_priors == {
+        k: Prior.from_json(v) for k, v in saturation.to_dict()["priors"].items()
+    }


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #950

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview pymc-marketing end -->